### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -53,7 +53,7 @@ jobs:
           docker build . --file Dockerfile --build-arg JAR_FILE=target/gateway-service-${{ env.release_version }}.jar --tag vpnbeast/gateway-service:latest
           docker tag vpnbeast/gateway-service:latest vpnbeast/gateway-service:${{ env.release_version }}
       - name: Publish to Registry
-        uses: elgohr/Publish-Docker-Github-Action@master
+        uses: elgohr/Publish-Docker-Github-Action@v5
         with:
           name: vpnbeast/gateway-service
           tags: "latest,${{ env.release_version }}"


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore